### PR TITLE
Update main.tf

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -180,7 +180,7 @@ data "aws_iam_policy_document" "dynamodb" {
       type        = "AWS"
       identifiers = ["*"]
     }
-    resources = ["arn:aws:dynamodb:${var.aws_region}:table/*"]
+    resources = ["*"]
   }
 }
 


### PR DESCRIPTION
Got following error

`<> is not authorized to perform: dynamodb:GetItem on resource: arn:aws:dynamodb:eu-west-2:***:table/**table because no VPC endpoint policy allows the dynamodb:GetItem action"`

Manually updating the policy fixed it.

Refer a fix mentioned for Glue endpoint : https://docs.aws.amazon.com/IAM/latest/UserGuide/troubleshoot_access-denied.html
