### PR TITLE
fix: replace deprecated aws_region .id/.name with .region attribute

### DIFF
--- a/endpoints.tf
+++ b/endpoints.tf
@@ -28,7 +28,7 @@ resource "aws_vpc_endpoint" "this" {
   for_each = { for obj in var.vpc_endpoint_data : obj.service => obj }
 
   vpc_id             = aws_vpc.this.id
-  service_name       = "com.amazonaws.${data.aws_region.this.id}.${each.key}"
+  service_name       = "com.amazonaws.${data.aws_region.this.region}.${each.key}"
   vpc_endpoint_type  = each.key == "s3" || each.key == "dynamodb" ? "Gateway" : "Interface"
   route_table_ids    = each.value.route_table_filter == "private" ? data.aws_route_tables.private[0].ids : concat(data.aws_route_tables.private[0].ids, data.aws_route_tables.public[0].ids)
   policy             = each.value.policy_doc == null ? local.endpoint_policies[each.key] : each.value.policy_doc

--- a/locals.tf
+++ b/locals.tf
@@ -34,7 +34,7 @@ locals {
         Sid    = "AllowCloudWatchLogs"
         Effect = "Allow"
         Principal = {
-          Service = "logs.${data.aws_region.current.id}.amazonaws.com"
+          Service = "logs.${data.aws_region.current.region}.amazonaws.com"
         }
         Action = [
           "kms:Encrypt",


### PR DESCRIPTION
The AWS provider v6.x deprecated data.aws_region .id and .name attributes. Updated locals.tf and endpoints.tf to use .region instead.

## Description

Please provide a brief description of the changes introduced by this pull request.

## Related Issue

- [[Issue Number](https://github.com/sourcefuse/terraform-aws-arc-network/issues/109)](link-to-issue): 

## Checklist

Please ensure that the following steps are completed before submitting the pull request:

- [ ] Code follows the Terraform best practices and style guidelines.
- [ ] Changes are appropriately documented, including any necessary updates to README or other documentation files.
- [ ] Unit tests have been added or updated to cover the changes introduced by this pull request.
- [ ] Changes have been tested locally and verified to work as expected.
- [ ] The code has been reviewed to ensure it aligns with the project's goals and standards.
- [ ] Dependencies and backward compatibility have been considered and addressed if applicable.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## Testing Instructions

Provide detailed steps or instructions for testing the changes introduced by this pull request.

## Screenshots

Include any relevant screenshots or visual aids to help reviewers understand the changes visually, if applicable.

## Additional Notes

Add any additional notes or context that might be helpful for reviewers or users testing the changes.
